### PR TITLE
Enable multi region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ resource "aws_kms_key" "sm_kms_key" {
       "Name" = format("%s", var.secret_id)
     },
   )
+  multi_region = var.multi_region
 }
 
 # alias for the key
@@ -301,6 +302,12 @@ variable "secrets_saml_users" {
 }
 
 variable "region" {}
+
+variable "multi_region" {
+  description = "if true, KMS key is created as multi-region"
+  type = bool
+  default = false
+}
 
 variable "secret_id" {}
 

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ locals {
     "kms:PutKeyPolicy",
     "kms:ReEncryptFrom",
     "kms:ReEncryptTo",
+    "kms:ReplicateKey",
     "kms:RetireGrant",
     "kms:RevokeGrant",
     "kms:ScheduleKeyDeletion",


### PR DESCRIPTION
Allow the key to be created as multiregion (still have to separately create the replicas in each replica region). 